### PR TITLE
The number of unrelateds is not reported correctly

### DIFF
--- a/src/data_read.cpp
+++ b/src/data_read.cpp
@@ -22,7 +22,7 @@ void data::readPedigrees(string fped) {
 			switch (type) {
 				case 2: n_tri ++; break;
 				case 1: n_duo ++; break;
-				default: n_tri ++; break;
+				default: n_unr ++; break;
 			}
 		}
 	}


### PR DESCRIPTION
@odelaneau thanks for sharing this tool, it's very helpful!
Here is a fix of a minor typo leading to incorrectly reported number of unrelated individuals.
Do you have the machine / environment used to build this tool? I'm using the pre-compiled binary  (in the ``bin``) folder, that would be great to get an updated version that include this fix - but if you need to configure build environment again I could also try harder to build it on my end.
Thanks again!